### PR TITLE
move predict.db to build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,11 @@ jobs:
       - name: Build predict.db
         working-directory: build/bin
         run: |
+          mkdir build
           wget https://github.com/rime/librime-predict/releases/download/data-1.0/predict.txt
-          wget -O release.db https://github.com/rime/librime-predict/releases/download/data-1.0/predict.db
-          cat predict.txt | ../plugins/predict/bin/build_predict
-          diff predict.db release.db
+          wget -O build/release.db https://github.com/rime/librime-predict/releases/download/data-1.0/predict.db
+          cat predict.txt | ../plugins/predict/bin/build_predict build/predict.db
+          diff build/{predict,release}.db
 
       - name: Test
         working-directory: build/bin

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 librime plugin. predict next word.
 
 ## Usage
-* Put the db file (by default `predict.db`) in rime user directory.
+* Put the db file (by default `predict.db`) in `build/` under rime user directory.
 * In `*.schema.yaml`, add `predictor` to the list of `engine/processors` before `key_binder`,
 or patch the schema with: `engine/processors/@before 0: predictor`
 * Add the `prediction` switch:

--- a/src/predictor.cc
+++ b/src/predictor.cc
@@ -136,7 +136,8 @@ Predictor* PredictorComponent::Create(const Ticket& ticket) {
   }
   if (!db_ || db_->file_name() != db_file) {
     the<ResourceResolver> res(
-        Service::instance().CreateResourceResolver({"predict_db", "", ""}));
+        Service::instance().CreateDeployedResourceResolver(
+            {"predict_db", "", ""}));
     string path = res->ResolvePath(db_file).string();
     auto db = std::make_unique<PredictDb>(path);
     if (db && db->Load()) {


### PR DESCRIPTION
In order to support dynamic deployment with user dictionary involved, the first step is to move the expected location of binary db from `"rime user dir"` to `"rime user dir"/build`.