### PR TITLE
fix wrongfully predicting after ascii clear & polish wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,28 +2,29 @@
 librime plugin. predict next word.
 
 ## Usage
-* Put the db file (by default `predict.db`) in `build/` under rime user directory.
-* In `*.schema.yaml`, add `predictor` to the list of `engine/processors` before `key_binder`,
-or patch the schema with: `engine/processors/@before 0: predictor`
+* Put the `.db` file (by default `predict.db`) in `build/` under rime's user directory.
+* In `*.schema.yaml`, add `predictor` to the list of `engine/processors` at the end, after `express_editor`/`fluid_editor`;
+alternatively, patch the schema with `engine/processors/+: predictor`
 * Add the `prediction` switch:
 ```yaml
 switches:
   - name: prediction
-    states: [ 关闭预测, 开启预测 ]
+    states: [ 關閉預測, 開啓預測 ]
     reset: 1
 ```
-* Config items for your predictor:
+* Configure your predictor:
 ```yaml
 predictor:
-  # predict db file in user directory/shared directory
-  # default to 'predict.db'
+  # put the `.db` predictor file in user directory/shared directory
+  # defaults to 'predict.db'
   db: predict.db
-  # max prediction candidates every time
-  # default to 0, which means showing all candidates
-  # you may set it the same with page_size so that period doesn't trigger next page
+  # max number of candidates for one iteration of prediction;
+  # defaults to 0, which means showing all possible candidates.
+  # you may want to set it the same as `page_size`, such that
+  # `page_down` (especially `.` as `page_down`) does not trigger paging
   max_candidates: 5
-  # max continuous prediction times
-  # default to 0, which means no limitation
+  # max number of consecutive iterations of prediction;
+  # defaults to 0, which means no limitation
   max_iterations: 1
 ```
 * Deploy and enjoy.

--- a/src/predictor.cc
+++ b/src/predictor.cc
@@ -26,13 +26,13 @@ Predictor::Predictor(const Ticket& ticket,
   auto* context = engine_->context();
   select_connection_ = context->select_notifier().connect(
       [this](Context* ctx) { OnSelect(ctx); });
-  context_update_connection_ = context->update_notifier().connect(
-      [this](Context* ctx) { OnContextUpdate(ctx); });
+  commit_connection_ = context->commit_notifier().connect(
+      [this](Context* ctx) { OnCommit(ctx); });
 }
 
 Predictor::~Predictor() {
   select_connection_.disconnect();
-  context_update_connection_.disconnect();
+  commit_connection_.disconnect();
 }
 
 ProcessResult Predictor::ProcessKeyEvent(const KeyEvent& key_event) {
@@ -55,7 +55,7 @@ void Predictor::OnSelect(Context* ctx) {
   last_action_ = kSelect;
 }
 
-void Predictor::OnContextUpdate(Context* ctx) {
+void Predictor::OnCommit(Context* ctx) {
   if (!db_ || !ctx || !ctx->composition().empty() ||
       !ctx->get_option("prediction"))
     return;

--- a/src/predictor.h
+++ b/src/predictor.h
@@ -19,7 +19,7 @@ class Predictor : public Processor {
   ProcessResult ProcessKeyEvent(const KeyEvent& key_event) override;
 
  protected:
-  void OnContextUpdate(Context* ctx);
+  void OnCommit(Context* ctx);
   void OnSelect(Context* ctx);
   void Predict(Context* ctx, const string& context_query);
 
@@ -32,7 +32,7 @@ class Predictor : public Processor {
 
   PredictDb* db_;
   connection select_connection_;
-  connection context_update_connection_;
+  connection commit_connection_;
 };
 
 class PredictorComponent : public Predictor::Component {


### PR DESCRIPTION
This PR fixes the bug where predictor wrongfully predicts after toggle ascii mode with clear (or other actions that updates context by clearing compositions without committance, for that matter). There is really no need at all to put prediction front in the processor list. It works fine at the end of the list, and it only needs to response to commit but not other context updates.