### PR TITLE
refactor: separate out predict_translator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,6 @@ jobs:
       - name: Test
         working-directory: build/bin
         run: |
-          sed -i '48a \    - predictor' luna_pinyin.schema.yaml
-          sed -i '37a \  - name: prediction\n    states: [ 关闭预测, 开启预测 ]\n    reset: 1' luna_pinyin.schema.yaml
+          cp ../../plugins/predict/data/luna_pinyin.custom.yaml .
           echo -e 'nihao \n ' | ./rime_api_console | tee log
           grep 'commit: 嗎' log

--- a/README.md
+++ b/README.md
@@ -4,12 +4,19 @@ librime plugin. predict next word.
 ## Usage
 * Put the db file (by default `predict.db`) in rime user directory.
 * In `*.schema.yaml`, add `predictor` to the list of `engine/processors` before `key_binder`,
-or patch the schema with: `engine/processors/@before 0: predictor`
+add `predict_translator` to the list of `engine/translators`;
+or patch the schema with:
+```yaml
+patch:
+  'engine/processors/@before 0': predictor
+  'engine/translators/@before 0': predict_translator
+```
+
 * Add the `prediction` switch:
 ```yaml
 switches:
   - name: prediction
-    states: [ 关闭预测, 开启预测 ]
+    states: [ 關閉預測, 開啓預測 ]
     reset: 1
 ```
 * Config items for your predictor:

--- a/data/luna_pinyin.custom.yaml
+++ b/data/luna_pinyin.custom.yaml
@@ -1,0 +1,10 @@
+patch:
+  'engine/processors/@after 0': predictor
+  'engine/translators/@before 0': predict_translator
+  'switches/+':
+    - name: prediction
+      reset: 1
+  predictor:
+    db: predict.db
+    max_iterations: 3
+    max_candidates: 10

--- a/src/predict_engine.cc
+++ b/src/predict_engine.cc
@@ -1,0 +1,123 @@
+#include "predict_engine.h"
+
+#include "predict_db.h"
+#include <rime/candidate.h>
+#include <rime/context.h>
+#include <rime/engine.h>
+#include <rime/key_event.h>
+#include <rime/menu.h>
+#include <rime/segmentation.h>
+#include <rime/service.h>
+#include <rime/ticket.h>
+#include <rime/translation.h>
+#include <rime/schema.h>
+#include <rime/dict/db_pool_impl.h>
+
+namespace rime {
+
+static const ResourceType kPredictDbResourceType = {"predict_db", "", ""};
+
+PredictEngine::PredictEngine(an<PredictDb> db,
+                             int max_iterations,
+                             int max_candidates)
+    : db_(db),
+      max_iterations_(max_iterations),
+      max_candidates_(max_candidates) {}
+
+PredictEngine::~PredictEngine() {}
+
+bool PredictEngine::Predict(Context* ctx, const string& context_query) {
+  DLOG(INFO) << "PredictEngine::Predict [" << context_query << "]";
+  if (const auto* candidates = db_->Lookup(context_query)) {
+    query_ = context_query;
+    candidates_ = candidates;
+    return true;
+  } else {
+    Clear();
+    return false;
+  }
+}
+
+void PredictEngine::Clear() {
+  DLOG(INFO) << "PredictEngine::Clear";
+  query_.clear();
+  candidates_ = nullptr;
+}
+
+void PredictEngine::CreatePredictSegment(Context* ctx) const {
+  DLOG(INFO) << "PredictEngine::CreatePredictSegment";
+  int end = int(ctx->input().length());
+  Segment segment(end, end);
+  segment.tags.insert("prediction");
+  segment.tags.insert("placeholder");
+  ctx->composition().AddSegment(segment);
+  ctx->composition().back().tags.erase("raw");
+  DLOG(INFO) << "segments: " << ctx->composition();
+}
+
+an<Translation> PredictEngine::Translate(const Segment& segment) const {
+  DLOG(INFO) << "PredictEngine::Translate";
+  auto translation = New<FifoTranslation>();
+  size_t end = segment.end;
+  int i = 0;
+  for (auto* it = candidates_->begin(); it != candidates_->end(); ++it) {
+    translation->Append(
+        New<SimpleCandidate>("prediction", end, end, db_->GetEntryText(*it)));
+    i++;
+    if (max_candidates_ > 0 && i >= max_candidates_)
+      break;
+  }
+  return translation;
+}
+
+PredictEngineComponent::PredictEngineComponent()
+    : db_pool_(the<ResourceResolver>(
+          Service::instance().CreateResourceResolver(kPredictDbResourceType))) {
+}
+
+PredictEngineComponent::~PredictEngineComponent() {}
+
+PredictEngine* PredictEngineComponent::Create(const Ticket& ticket) {
+  string db_name = "predict.db";
+  int max_candidates = 0;
+  int max_iterations = 0;
+  if (auto* schema = ticket.schema) {
+    auto* config = schema->config();
+    if (config->GetString("predictor/db", &db_name)) {
+      LOG(INFO) << "custom predictor/db: " << db_name;
+    }
+    if (!config->GetInt("predictor/max_candidates", &max_candidates)) {
+      LOG(INFO) << "predictor/max_candidates is not set in schema";
+    }
+    if (!config->GetInt("predictor/max_iterations", &max_iterations)) {
+      LOG(INFO) << "predictor/max_iterations is not set in schema";
+    }
+  }
+  if (auto db = db_pool_.GetDb(db_name)) {
+    if (db->IsOpen() || db->Load()) {
+      return new PredictEngine(db, max_iterations, max_candidates);
+    } else {
+      LOG(ERROR) << "failed to load predict db: " << db_name;
+    }
+  }
+  return nullptr;
+}
+
+an<PredictEngine> PredictEngineComponent::GetInstance(const Ticket& ticket) {
+  if (Schema* schema = ticket.schema) {
+    auto found = predict_engine_by_schema_id.find(schema->schema_id());
+    if (found != predict_engine_by_schema_id.end()) {
+      if (auto instance = found->second.lock()) {
+        return instance;
+      }
+    }
+    an<PredictEngine> new_instance{Create(ticket)};
+    if (new_instance) {
+      predict_engine_by_schema_id[schema->schema_id()] = new_instance;
+      return new_instance;
+    }
+  }
+  return nullptr;
+}
+
+}  // namespace rime

--- a/src/predict_engine.h
+++ b/src/predict_engine.h
@@ -1,0 +1,57 @@
+#ifndef RIME_PREDICT_ENGINE_H_
+#define RIME_PREDICT_ENGINE_H_
+
+#include "predict_db.h"
+#include <rime/component.h>
+#include <rime/dict/db_pool.h>
+
+namespace rime {
+
+class Context;
+class Segment;
+class Ticket;
+class Translation;
+
+class PredictEngine : public Class<PredictEngine, const Ticket&> {
+ public:
+  PredictEngine(an<PredictDb> db, int max_iterations, int max_candidates);
+  virtual ~PredictEngine();
+
+  bool Predict(Context* ctx, const string& context_query);
+  void Clear();
+  void CreatePredictSegment(Context* ctx) const;
+  an<Translation> Translate(const Segment& segment) const;
+
+  int max_iterations() const { return max_iterations_; }
+  int max_candidates() const { return max_candidates_; }
+  const string& query() const { return query_; }
+  int num_candidates() const { return candidates_ ? candidates_->size : 0; }
+  string candidate(size_t i) const {
+    return candidates_ ? db_->GetEntryText(candidates_->at[i]) : string();
+  }
+
+ private:
+  an<PredictDb> db_;
+  int max_iterations_;  // prediction times limit
+  int max_candidates_;  // prediction candidate count limit
+  string query_;        // cache last query
+  const predict::Candidates* candidates_ = nullptr;  // cache last result
+};
+
+class PredictEngineComponent : public PredictEngine::Component {
+ public:
+  PredictEngineComponent();
+  virtual ~PredictEngineComponent();
+
+  PredictEngine* Create(const Ticket& ticket) override;
+
+  an<PredictEngine> GetInstance(const Ticket& ticket);
+
+ protected:
+  map<string, weak<PredictEngine>> predict_engine_by_schema_id;
+  DbPool<PredictDb> db_pool_;
+};
+
+}  // namespace rime
+
+#endif  // RIME_PREDICT_ENGINE_H_

--- a/src/predict_module.cc
+++ b/src/predict_module.cc
@@ -3,12 +3,17 @@
 #include <rime_api.h>
 
 #include "predictor.h"
+#include "predict_engine.h"
+#include "predict_translator.h"
 
 using namespace rime;
 
 static void rime_predict_initialize() {
   Registry& r = Registry::instance();
-  r.Register("predictor", new PredictorComponent);
+  an<PredictEngineComponent> engine_factory = New<PredictEngineComponent>();
+  r.Register("predictor", new PredictorComponent(engine_factory));
+  r.Register("predict_translator",
+             new PredictTranslatorComponent(engine_factory));
 }
 
 static void rime_predict_finalize() {}

--- a/src/predict_translator.cc
+++ b/src/predict_translator.cc
@@ -1,0 +1,52 @@
+#include "predict_translator.h"
+
+#include "predict_engine.h"
+#include <rime/candidate.h>
+#include <rime/context.h>
+#include <rime/engine.h>
+#include <rime/key_event.h>
+#include <rime/menu.h>
+#include <rime/segmentation.h>
+#include <rime/service.h>
+#include <rime/translation.h>
+#include <rime/schema.h>
+#include <rime/dict/db_pool_impl.h>
+
+namespace rime {
+
+PredictTranslator::PredictTranslator(const Ticket& ticket,
+                                     an<PredictEngine> predict_engine)
+    : Translator(ticket), predict_engine_(predict_engine) {}
+
+an<Translation> PredictTranslator::Query(const string& input,
+                                         const Segment& segment) {
+  if (predict_engine_->query().empty() || !segment.HasTag("prediction")) {
+    return nullptr;
+  }
+  int num_candidates = predict_engine_->num_candidates();
+  if (num_candidates > 0) {
+    int max_candidates = predict_engine_->max_candidates();
+    auto translation = New<FifoTranslation>();
+    size_t end = segment.end;
+    for (int i = 0; i < num_candidates; ++i) {
+      translation->Append(New<SimpleCandidate>("prediction", end, end,
+                                               predict_engine_->candidate(i)));
+      if (max_candidates > 0 && i >= max_candidates)
+        break;
+    }
+    return translation;
+  }
+  return nullptr;
+}
+
+PredictTranslatorComponent::PredictTranslatorComponent(
+    an<PredictEngineComponent> engine_factory)
+    : engine_factory_(engine_factory) {}
+
+PredictTranslatorComponent::~PredictTranslatorComponent() {}
+
+PredictTranslator* PredictTranslatorComponent::Create(const Ticket& ticket) {
+  return new PredictTranslator(ticket, engine_factory_->GetInstance(ticket));
+}
+
+}  // namespace rime

--- a/src/predict_translator.h
+++ b/src/predict_translator.h
@@ -1,0 +1,36 @@
+#ifndef RIME_PREDICT_TRANSLATOR_H_
+#define RIME_PREDICT_TRANSLATOR_H_
+
+#include <rime/translator.h>
+
+namespace rime {
+
+class Context;
+class PredictEngine;
+class PredictEngineComponent;
+
+class PredictTranslator : public Translator {
+ public:
+  PredictTranslator(const Ticket& ticket, an<PredictEngine> predict_engine);
+
+  an<Translation> Query(const string& input, const Segment& segment) override;
+
+ private:
+  an<PredictEngine> predict_engine_;
+};
+
+class PredictTranslatorComponent : public PredictTranslator::Component {
+ public:
+  explicit PredictTranslatorComponent(
+      an<PredictEngineComponent> engine_factory);
+  virtual ~PredictTranslatorComponent();
+
+  PredictTranslator* Create(const Ticket& ticket) override;
+
+ protected:
+  an<PredictEngineComponent> engine_factory_;
+};
+
+}  // namespace rime
+
+#endif  // RIME_PREDICT_TRANSLATOR_H_

--- a/src/predictor.h
+++ b/src/predictor.h
@@ -6,14 +6,12 @@
 namespace rime {
 
 class Context;
-class PredictDb;
+class PredictEngine;
+class PredictEngineComponent;
 
 class Predictor : public Processor {
  public:
-  Predictor(const Ticket& ticket,
-            PredictDb* db,
-            int max_candidates,
-            int max_iterations);
+  Predictor(const Ticket& ticket, an<PredictEngine> predict_engine);
   virtual ~Predictor();
 
   ProcessResult ProcessKeyEvent(const KeyEvent& key_event) override;
@@ -21,29 +19,28 @@ class Predictor : public Processor {
  protected:
   void OnContextUpdate(Context* ctx);
   void OnSelect(Context* ctx);
-  void Predict(Context* ctx, const string& context_query);
+  void PredictAndUpdate(Context* ctx, const string& context_query);
 
  private:
   enum Action { kUnspecified, kSelect, kDelete };
   Action last_action_ = kUnspecified;
-  int max_iterations_;     // prediction times limit
-  int max_candidates_;     // prediction candidate count limit
-  int iteration_counter_;  // times has been predicted
+  bool self_updating_ = false;
+  int iteration_counter_ = 0;  // times has been predicted
 
-  PredictDb* db_;
+  an<PredictEngine> predict_engine_;
   connection select_connection_;
   connection context_update_connection_;
 };
 
 class PredictorComponent : public Predictor::Component {
  public:
-  PredictorComponent();
+  explicit PredictorComponent(an<PredictEngineComponent> engine_factory);
   virtual ~PredictorComponent();
 
   Predictor* Create(const Ticket& ticket) override;
 
  protected:
-  the<PredictDb> db_;
+  an<PredictEngineComponent> engine_factory_;
 };
 
 }  // namespace rime


### PR DESCRIPTION
the database and config are shared among `Predictor` and `PredictTranslator` objects through a shared `PredictEngine`.